### PR TITLE
Separate response validation from the Middleware so that ServiceProvi…

### DIFF
--- a/samlsp/samlsp.go
+++ b/samlsp/samlsp.go
@@ -53,13 +53,14 @@ func New(opts Options) (*Middleware, error) {
 
 	m := &Middleware{
 		ServiceProvider: saml.ServiceProvider{
-			Key:         opts.Key,
-			Logger:      logr,
-			Certificate: opts.Certificate,
-			MetadataURL: *metadataURL,
-			AcsURL:      *acsURL,
-			IDPMetadata: opts.IDPMetadata,
-			ForceAuthn:  &opts.ForceAuthn,
+			Key:               opts.Key,
+			Logger:            logr,
+			Certificate:       opts.Certificate,
+			MetadataURL:       *metadataURL,
+			AcsURL:            *acsURL,
+			IDPMetadata:       opts.IDPMetadata,
+			ForceAuthn:        &opts.ForceAuthn,
+			AllowIDPInitiated: opts.AllowIDPInitiated,
 		},
 		AllowIDPInitiated: opts.AllowIDPInitiated,
 		TokenMaxAge:       tokenMaxAge,


### PR DESCRIPTION
…der can be used standalone to validate requests. Also fix IDPInitiated requestids bug since Standalone validation may not have possibleRequestIds.